### PR TITLE
Compatibility with ghc 9.10

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -33,6 +33,11 @@ jobs:
             compilerVersion: 9.12.1
             setup-method: ghcup
             allow-failure: false
+          - compiler: ghc-9.10.1
+            compilerKind: ghc
+            compilerVersion: 9.10.1
+            setup-method: ghcup
+            allow-failure: false
       fail-fast: false
     steps:
       - name: apt-get install

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ processing the event log yourself or by using
 
 ## Limitations and future work
 
-* Requires GHC 9.12
+* Requires GHC 9.10 or 9.12
+  (profiling of _pure_ foreign imports requires ghc 9.12).
 * Standard time profiling tools can _NOT_ be used on the eventlog.
 * It is not possible to profile Haskell functions and FFI functions at the
   same time.

--- a/example-pkg-A/example-pkg-A.cabal
+++ b/example-pkg-A/example-pkg-A.cabal
@@ -12,14 +12,14 @@ category:           Development
 build-type:         Simple
 extra-source-files: cbits/cbits.h
                     cbits/cbits.c
-tested-with:        GHC ==9.12.1
+tested-with:        GHC ==9.10.1
+                    GHC ==9.12.1
 
 common lang
   ghc-options:
       -Wall
   build-depends:
-      -- For now we don't support ghc < 9.12
-      base >= 4.21 && < 4.22
+      base >= 4.20 && < 4.22
   default-language:
       GHC2021
 

--- a/example-pkg-B/example-pkg-B.cabal
+++ b/example-pkg-B/example-pkg-B.cabal
@@ -12,14 +12,14 @@ author:             Edsko de Vries
 maintainer:         edsko@well-typed.com
 category:           Development
 build-type:         Simple
-tested-with:        GHC ==9.12.1
+tested-with:        GHC ==9.10.1
+                    GHC ==9.12.1
 
 common lang
   ghc-options:
       -Wall
   build-depends:
-      -- For now we don't support ghc < 9.12
-      base >= 4.21 && < 4.22
+      base >= 4.20 && < 4.22
   default-language:
       GHC2021
 

--- a/trace-foreign-calls/src/Plugin/TraceForeignCalls/GHC/Shim.hs
+++ b/trace-foreign-calls/src/Plugin/TraceForeignCalls/GHC/Shim.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Plugin.TraceForeignCalls.GHC.Shim (
+    mkLambda
+  , mkSimpleFunRhs
+  , mkValBinds
+  , extendValBinds
+  , mkMatch
+  , mkSimpleFunBind
+  , checkHaveSeq
+  ) where
+
+import Data.Bifunctor (second)
+import Data.Maybe (isJust)
+
+import GHC
+import GHC.Builtin.Names qualified as Names
+import GHC.Data.Bag (listToBag)
+import GHC.Driver.Env (hsc_HUG)
+import GHC.Tc.Utils.Monad (TcGblEnv)
+import GHC.Tc.Utils.Monad qualified as TC
+import GHC.Types.Basic
+import GHC.Types.Name.Set (mkNameSet)
+import GHC.Unit.Env (lookupHugByModule)
+import GHC.Unit.Types (ghcInternalUnit)
+
+import Plugin.TraceForeignCalls.GHC.Util
+
+mkLambda :: [LPat GhcRn] -> LHsExpr GhcRn -> LHsExpr GhcRn
+#if MIN_VERSION_ghc(9,12,1)
+mkLambda = mkHsLam . noLocValue
+#else
+mkLambda = mkHsLam
+#endif
+
+mkSimpleFunRhs :: LIdP GhcRn -> HsMatchContext (LIdP GhcRn)
+mkSimpleFunRhs name = FunRhs {
+      mc_fun        = name
+    , mc_fixity     = Prefix
+    , mc_strictness = NoSrcStrict
+#if MIN_VERSION_ghc(9,12,1)
+    , mc_an         = AnnFunRhs NoEpTok [] []
+#endif
+    }
+
+mkValBinds :: [(RecFlag, [LHsBind GhcRn])] -> [LSig GhcRn] -> HsValBinds GhcRn
+#if MIN_VERSION_ghc(9,12,1)
+mkValBinds bindingGroups sigs =
+    XValBindsLR $
+      NValBinds bindingGroups sigs
+#else
+mkValBinds bindingGroups sigs =
+    XValBindsLR $
+      NValBinds (map (second listToBag) bindingGroups) sigs
+#endif
+
+extendValBinds ::
+     [(RecFlag, [LHsBind GhcRn])]
+  -> [LSig GhcRn]
+  -> HsValBinds GhcRn -> HsValBinds GhcRn
+#if MIN_VERSION_ghc(9,12,1)
+extendValBinds newBindingGroups newSigs old =
+    case old of
+      XValBindsLR (NValBinds oldGroups oldSigs) ->
+        XValBindsLR $
+          NValBinds
+            (oldGroups ++ newBindingGroups)
+            (oldSigs   ++ newSigs)
+      ValBinds{} ->
+        error "impossible (ValBinds is only used before renaming)"
+#else
+extendValBinds newBindingGroups newSigs old =
+    case old of
+      XValBindsLR (NValBinds oldGroups oldSigs) ->
+        XValBindsLR $
+          NValBinds
+            (oldGroups ++ map (second listToBag) newBindingGroups)
+            (oldSigs   ++ newSigs)
+      ValBinds{} ->
+        error "impossible (ValBinds is only used before renaming)"
+#endif
+
+mkSimpleFunBind ::
+     LIdP GhcRn     -- ^ Name of the function
+  -> [Name]         -- ^ Free variables in the body (excluding imports)
+  -> [Name]         -- ^ Arguments
+  -> LHsExpr GhcRn  -- ^ Body
+  -> LHsBind GhcRn
+mkSimpleFunBind name freeVars args body = noLocValue $ FunBind {
+      fun_ext     = mkNameSet freeVars
+    , fun_id      = name
+    , fun_matches = MG {
+          mg_ext  = Generated OtherExpansion SkipPmc
+        , mg_alts = noLocValue . map noLocValue $ [
+             Match {
+#if MIN_VERSION_ghc(9,12,1)
+                 m_ext   = noValue
+#else
+                 m_ext   = noAnn
+#endif
+               , m_ctxt  = mkSimpleFunRhs name
+#if MIN_VERSION_ghc(9,12,1)
+               , m_pats  = noLocValue $ map namedVarPat args
+#else
+               , m_pats  = map namedVarPat args
+#endif
+               , m_grhss = GRHSs {
+                     grhssExt        = emptyComments
+                   , grhssGRHSs      = map noLocValue [
+                         GRHS
+                           noValue
+                           [] -- guards
+                           body
+                       ]
+                   , grhssLocalBinds = emptyWhereClause
+                   }
+               }
+           ]
+        }
+    }
+
+-- | Check if @seq#@ is available
+--
+-- For now we only support the use of @seq#@ (and hence profiling pure
+-- functions) for GHC 9.12.
+checkHaveSeq :: TcGblEnv -> HscEnv -> Bool
+#if MIN_VERSION_ghc_internal(9,1201,0)
+checkHaveSeq tcGblEnv hsc =
+    if moduleUnit (TC.tcg_mod tcGblEnv) == ghcInternalUnit
+      then isJust $ lookupHugByModule Names.gHC_INTERNAL_IO (hsc_HUG hsc)
+      else True
+#else
+checkHaveSeq _ _ = False
+#endif
+

--- a/trace-foreign-calls/src/Plugin/TraceForeignCalls/Instrument.hs
+++ b/trace-foreign-calls/src/Plugin/TraceForeignCalls/Instrument.hs
@@ -13,20 +13,18 @@ module Plugin.TraceForeignCalls.Instrument (
 
 import Control.Monad
 import Control.Monad.IO.Class
-import Data.Maybe (isJust)
 
 import GHC
 import GHC.Plugins hiding (getHscEnv)
 
-import GHC.Builtin.Names qualified as Names
 import GHC.Platform.Ways (Way(WayProf), hasWay)
 import GHC.Tc.Utils.Monad (TcM, TcGblEnv)
 import GHC.Tc.Utils.Monad qualified as TC
-import GHC.Unit.Env (lookupHugByModule)
 import GHC.Utils.Logger (HasLogger(..))
 
+import Plugin.TraceForeignCalls.GHC.Util
+import Plugin.TraceForeignCalls.GHC.Shim
 import Plugin.TraceForeignCalls.Options
-import Plugin.TraceForeignCalls.Util.GHC
 
 {-------------------------------------------------------------------------------
   Definition
@@ -174,12 +172,6 @@ mkNames tcGblEnv = do
 
 findName :: (Names -> a) -> Instrument a
 findName f = Wrap $ return . f . tracerEnvNames
-
-checkHaveSeq :: TcGblEnv -> HscEnv -> Bool
-checkHaveSeq tcGblEnv hsc =
-    if moduleUnit (TC.tcg_mod tcGblEnv) == ghcInternalUnit
-      then isJust $ lookupHugByModule Names.gHC_INTERNAL_IO (hsc_HUG hsc)
-      else True
 
 checkProfiling :: DynFlags -> Bool
 checkProfiling df = sccProfilingEnabled df && ways df `hasWay` WayProf

--- a/trace-foreign-calls/src/Plugin/TraceForeignCalls/Options.hs
+++ b/trace-foreign-calls/src/Plugin/TraceForeignCalls/Options.hs
@@ -12,7 +12,7 @@ import Data.String
 import GHC
 import GHC.Utils.Outputable
 
-import Plugin.TraceForeignCalls.Util.GHC
+import Plugin.TraceForeignCalls.GHC.Util
 
 {-------------------------------------------------------------------------------
   Definition

--- a/trace-foreign-calls/trace-foreign-calls.cabal
+++ b/trace-foreign-calls/trace-foreign-calls.cabal
@@ -17,7 +17,8 @@ build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 extra-source-files: test-cbits/test_cbits.h
                     test-cbits/test_cbits.c
-tested-with:        GHC ==9.12.1
+tested-with:        GHC ==9.10.1
+                    GHC ==9.12.1
 
 source-repository head
   type:     git
@@ -25,8 +26,8 @@ source-repository head
 
 common lang
   build-depends:
-      -- For now we don't support ghc < 9.12
-      base >= 4.21 && < 4.22
+      -- ghc 9.10 or 9.12
+      base >= 4.20 && < 4.22
   default-language:
       GHC2021
   ghc-options:
@@ -34,7 +35,6 @@ common lang
       -Wredundant-constraints
       -Wprepositive-qualified-module
       -Widentities
-      -Wunused-packages
 
 library
   import:
@@ -44,14 +44,16 @@ library
   other-modules:
       Plugin.TraceForeignCalls.Instrument
       Plugin.TraceForeignCalls.Options
-      Plugin.TraceForeignCalls.Util.GHC
+      Plugin.TraceForeignCalls.GHC.Util
+      Plugin.TraceForeignCalls.GHC.Shim
   hs-source-dirs:
       src
   build-depends:
       -- dependencies intentionally kept at a minimum
       -- (we want to be able to build the boot libs with this plugin)
-    , ghc >= 9.12 && < 9.14
+    , ghc >= 9.10 && < 9.14
     , ghc-boot
+    , ghc-internal
 
 test-suite test-trace-foreign-calls
   import:


### PR DESCRIPTION
This is primarily useful for building the boot libraries.
    
When building with `ghc-internals` for 9.10, we do not support `seq#`.
